### PR TITLE
Bring menu to the front before displaying.

### DIFF
--- a/Source/BTNavigationDropdownMenu.swift
+++ b/Source/BTNavigationDropdownMenu.swift
@@ -301,6 +301,8 @@ public class BTNavigationDropdownMenu: UIView {
         // Reload data to dismiss highlight color of selected cell
         self.tableView.reloadData()
         
+        self.menuWrapper.superview?.bringSubviewToFront(self.menuWrapper)
+        
         UIView.animateWithDuration(
             self.configuration.animationDuration * 1.5,
             delay: 0,


### PR DESCRIPTION
This is a fix for when BTNavigationDropdownMenu is used in the context of a `UITabBarController`. When the tab changes, the new view controller takes z-index priority, and prevents `menuWrapper` from being visible.