### PR TITLE
Fixed Issue #64 Crash While Unwrapping selectedIndexPath

### DIFF
--- a/Source/BTNavigationDropdownMenu.swift
+++ b/Source/BTNavigationDropdownMenu.swift
@@ -471,7 +471,7 @@ class BTTableView: UITableView, UITableViewDelegate, UITableViewDataSource {
     
     // Private properties
     private var items: [AnyObject]!
-    private var selectedIndexPath: Int!
+    private var selectedIndexPath: Int?
     
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")


### PR DESCRIPTION
Issue seems like occurs when given navigation title doesn't match any of items in the list.

Making selectedIndexPath optional seems enough to avoid crash.