### PR TITLE
Allow transparent cell backgrounds

### DIFF
--- a/Source/BTNavigationDropdownMenu.swift
+++ b/Source/BTNavigationDropdownMenu.swift
@@ -518,10 +518,6 @@ class BTTableView: UITableView, UITableViewDelegate, UITableViewDataSource {
         let cell = BTTableViewCell(style: UITableViewCellStyle.Default, reuseIdentifier: "Cell", configuration: self.configuration)
         cell.textLabel?.text = self.items[indexPath.row] as? String
         cell.checkmarkIcon.hidden = (indexPath.row == selectedIndexPath) ? false : true
-        if self.configuration.keepSelectedCellColor == true {
-            cell.contentView.backgroundColor = (indexPath.row == selectedIndexPath) ? self.configuration.cellSelectionColor : self.configuration.cellBackgroundColor
-        }
-        
         return cell
     }
     
@@ -538,6 +534,13 @@ class BTTableView: UITableView, UITableViewDelegate, UITableViewDataSource {
         let cell = tableView.cellForRowAtIndexPath(indexPath) as? BTTableViewCell
         cell?.checkmarkIcon.hidden = true
         cell?.contentView.backgroundColor = self.configuration.cellBackgroundColor
+    }
+
+    func tableView(tableView: UITableView, willDisplayCell cell: UITableViewCell, forRowAtIndexPath indexPath: NSIndexPath) {
+        if self.configuration.keepSelectedCellColor == true {
+            cell.backgroundColor = self.configuration.cellBackgroundColor
+            cell.contentView.backgroundColor = (indexPath.row == selectedIndexPath) ? self.configuration.cellSelectionColor : self.configuration.cellBackgroundColor
+        }
     }
 }
 


### PR DESCRIPTION
PR does two things:
 - Set cell `backgroundColor` to `cellBackgroundColor`. Previously only the contentView's background color was set. Since iOS 7, cells have a white background by default, so setting `cellBackgroundColor` to `clearColor()` displayed a white background instead of transparent.

- Use the `willDisplayCell:` UITableViewDelegate method instead of `cellForRowAtIndexPath:`. This is just a refactoring, but it follows Apple's guidelines of where to change the background color of a cell.

[1] https://developer.apple.com/library/ios/documentation/UIKit/Reference/UITableViewCell_Class/