### PR TITLE
Critical Crash bug

### DIFF
--- a/Source/BTNavigationDropdownMenu.swift
+++ b/Source/BTNavigationDropdownMenu.swift
@@ -200,6 +200,10 @@ public class BTNavigationDropdownMenu: UIView {
     public init(navigationController: UINavigationController? = nil, containerView: UIView = UIApplication.sharedApplication().keyWindow!, title: String, items: [AnyObject]) {
         
         // Navigation controller
+        guard let navigationController = navigationController else{
+            super.init(frame: CGRectZero)
+            return
+        }
         if let navigationController = navigationController {
             self.navigationController = navigationController
         } else {


### PR DESCRIPTION
This will return empty UIView, However, this will fix a potential crash bug.

I faced this bug in my production app, where as per my knowledge navigationcontroller being nill was handled properly and I couldn't reproduce this error on any of my test devices during development.
However, It got captured in  Crashlytics when the app was in production.
Applied this simple protection measure and app works as expected.

Bug Reported in Crashlytics : 
BTNavigationDropdownMenu.swift line 521
specialized BTTableView.tableView(UITableView, cellForRowAtIndexPath : NSIndexPath) -> UITableViewCell
BTNavigationDropdownMenu.swift line 0
@objc BTTableView.tableView(UITableView, cellForRowAtIndexPath : NSIndexPath) -> UITableViewCell