### PR TITLE
keep-selected-textcolor

### DIFF
--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -26,6 +26,7 @@ class ViewController: UIViewController {
         menuView.cellBackgroundColor = self.navigationController?.navigationBar.barTintColor
         menuView.cellSelectionColor = UIColor(red: 0.0/255.0, green:160.0/255.0, blue:195.0/255.0, alpha: 1.0)
         menuView.shouldKeepSelectedCellColor = true
+        menuView.shouldKeepSelectedCellTextColor = true
         menuView.cellTextLabelColor = UIColor.white
         menuView.cellTextLabelFont = UIFont(name: "Avenir-Heavy", size: 17)
         menuView.cellTextLabelAlignment = .left // .Center // .Right // .Left

--- a/Source/BTNavigationDropdownMenu.swift
+++ b/Source/BTNavigationDropdownMenu.swift
@@ -159,6 +159,16 @@ open class BTNavigationDropdownMenu: UIView {
         }
     }
     
+    // The boolean value that decides if selected color of text cell is visible when the menu is shown. Default is false
+    open var shouldKeepSelectedCellTextColor: Bool! {
+        get {
+            return self.configuration.shouldKeepSelectedCellTextColor
+        }
+        set(value) {
+            self.configuration.shouldKeepSelectedCellTextColor = value
+        }
+    }
+    
     // The animation duration of showing/hiding menu. Default is 0.3
     open var animationDuration: TimeInterval! {
         get {
@@ -483,6 +493,7 @@ class BTConfiguration {
     var cellSelectionColor: UIColor?
     var checkMarkImage: UIImage!
     var shouldKeepSelectedCellColor: Bool!
+    var shouldKeepSelectedCellTextColor: Bool!
     var arrowTintColor: UIColor?
     var arrowImage: UIImage!
     var arrowPadding: CGFloat!
@@ -517,6 +528,7 @@ class BTConfiguration {
         self.cellSelectionColor = UIColor.lightGray
         self.checkMarkImage = UIImage(contentsOfFile: checkMarkImagePath!)
         self.shouldKeepSelectedCellColor = false
+        self.shouldKeepSelectedCellTextColor = false
         self.animationDuration = 0.5
         self.arrowImage = UIImage(contentsOfFile: arrowImagePath!)
         self.arrowPadding = 15
@@ -606,6 +618,9 @@ class BTTableView: UITableView, UITableViewDelegate, UITableViewDataSource {
         if self.configuration.shouldKeepSelectedCellColor == true {
             cell.backgroundColor = self.configuration.cellBackgroundColor
             cell.contentView.backgroundColor = ((indexPath as NSIndexPath).row == selectedIndexPath) ? self.configuration.cellSelectionColor : self.configuration.cellBackgroundColor
+        }
+        if self.configuration.shouldKeepSelectedCellTextColor == true {
+            cell.textLabel?.textColor = ((indexPath as NSIndexPath).row == selectedIndexPath) ? self.configuration.selectedCellTextLabelColor : self.configuration.cellTextLabelColor
         }
     }
 }


### PR DESCRIPTION
Keep selected text color
- Add a new property with the same behavior as shouldKeepSelectedCellColor
- Keep both, so the now, the user can play with both
- Add the property as true, on the demo viewController