### PR TITLE
Added support for optional NSAttributedString, for cell text.

### DIFF
--- a/Source/BTItem.swift
+++ b/Source/BTItem.swift
@@ -1,0 +1,42 @@
+//
+//  BTItem.swift
+//
+//  Copyright (c) 2017 PHAM BA THO (phambatho@gmail.com). All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+
+/**
+
+ An struct to define both a String and optional NSAttributedString, for each item
+
+ - parameters:
+    - string: Define item String.
+    - attributeString: Define optional item NSAttributedString, used in UITableViewCell only.
+ */
+public struct BTItem {
+    let string: String
+    let attributedString: NSAttributedString?
+    
+    public  init(string: String, attributedString: NSAttributedString? = nil) {
+        self.string = string
+        self.attributedString = attributedString
+    }
+}

--- a/Source/BTNavigationDropdownMenu.swift
+++ b/Source/BTNavigationDropdownMenu.swift
@@ -231,7 +231,7 @@ open class BTNavigationDropdownMenu: UIView {
     fileprivate var menuArrow: UIImageView!
     fileprivate var backgroundView: UIView!
     fileprivate var tableView: BTTableView!
-    fileprivate var items: [String]!
+    fileprivate var items: [BTItem]!
     fileprivate var menuWrapper: UIView!
 
     required public init?(coder aDecoder: NSCoder) {
@@ -248,7 +248,7 @@ open class BTNavigationDropdownMenu: UIView {
         - title: A string to define title to be displayed.
         - items: The array of items to select
      */
-    public convenience init(navigationController: UINavigationController? = nil, containerView: UIView = UIApplication.shared.keyWindow!, title: String, items: [String]) {
+    public convenience init(navigationController: UINavigationController? = nil, containerView: UIView = UIApplication.shared.keyWindow!, title: String, items: [BTItem]) {
 
         self.init(navigationController: navigationController, containerView: containerView, title: BTTitle.title(title), items: items)
     }
@@ -265,7 +265,7 @@ open class BTNavigationDropdownMenu: UIView {
         - title: An enum to define title to be displayed, can be a string or index of items.
         - items: The array of items to select
      */
-    public init(navigationController: UINavigationController? = nil, containerView: UIView = UIApplication.shared.keyWindow!, title: BTTitle, items: [String]) {
+    public init(navigationController: UINavigationController? = nil, containerView: UIView = UIApplication.shared.keyWindow!, title: BTTitle, items: [BTItem]) {
         // Key window
         guard let window = UIApplication.shared.keyWindow else {
             super.init(frame: CGRect.zero)
@@ -286,7 +286,7 @@ open class BTNavigationDropdownMenu: UIView {
         switch title{
         case .index(let index):
             if index < items.count{
-                titleToDisplay = items[index]
+                titleToDisplay = items[index].string
             } else {
                 titleToDisplay = ""
             }
@@ -349,7 +349,7 @@ open class BTNavigationDropdownMenu: UIView {
             }
             selfie.didSelectItemAtIndexHandler!(indexPath)
             if selfie.shouldChangeTitleText! {
-                selfie.setMenuTitle("\(selfie.tableView.items[indexPath])")
+                selfie.setMenuTitle("\(selfie.tableView.items[indexPath].string)")
             }
             self?.hideMenu()
             self?.layoutSubviews()
@@ -406,7 +406,7 @@ open class BTNavigationDropdownMenu: UIView {
         }
     }
 
-    open func updateItems(_ items: [String]) {
+    open func updateItems(_ items: [BTItem]) {
         if !items.isEmpty {
             self.tableView.items = items
             self.tableView.reloadData()
@@ -418,7 +418,7 @@ open class BTNavigationDropdownMenu: UIView {
         self.tableView.reloadData()
 
         if self.shouldChangeTitleText! {
-            self.setMenuTitle("\(self.tableView.items[index])")
+            self.setMenuTitle("\(self.tableView.items[index].string)")
         }
     }
 

--- a/Source/Internal/BTTableView.swift
+++ b/Source/Internal/BTTableView.swift
@@ -30,18 +30,18 @@ class BTTableView: UITableView, UITableViewDelegate, UITableViewDataSource {
     var selectRowAtIndexPathHandler: ((_ indexPath: Int) -> ())?
     
     // Private properties
-    var items: [String] = []
+    var items: [BTItem] = []
     var selectedIndexPath: Int?
     
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    init(frame: CGRect, items: [String], title: String, configuration: BTConfiguration) {
+    init(frame: CGRect, items: [BTItem], title: String, configuration: BTConfiguration) {
         super.init(frame: frame, style: UITableView.Style.plain)
         
         self.items = items
-        self.selectedIndexPath = items.index(of: title)
+        self.selectedIndexPath = items.firstIndex(where: { $0.string == title })
         self.configuration = configuration
         
         // Setup table view
@@ -76,7 +76,11 @@ class BTTableView: UITableView, UITableViewDelegate, UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = BTTableViewCell(style: UITableViewCell.CellStyle.default, reuseIdentifier: "Cell", configuration: self.configuration)
-        cell.textLabel?.text = self.items[(indexPath as NSIndexPath).row]
+        if let attributedString = self.items[(indexPath as NSIndexPath).row].attributedString {
+            cell.textLabel?.attributedText = attributedString
+        } else {
+            cell.textLabel?.text = self.items[(indexPath as NSIndexPath).row].string
+        }
         cell.checkmarkIcon.isHidden = ((indexPath as NSIndexPath).row == selectedIndexPath) ? false : true
         return cell
     }


### PR DESCRIPTION
Hey, Tho.  So, I wanted to use Apple's Symbols (as images) in my cells, so switched to using **NSAttributedStrings** with **NSTextAttachments**, for each **UITableViewCell**.

In this PR, I added support for an optional NSAttributedString to set the cell's attributedText instead.  **items** are now an array of type **BTItem**, which is a struct I created with a _String_ and an optional **NSAttributedString**.  If a NSAttributedString is set for an item, it will use that instead.

I don't know if would be popular or not, since it is a breaking change with the previous array of Strings, for items, but otherwise it works the same.  One would just pass in BTItem(string: "Text"), instead of "Text" for each element.

-Stu